### PR TITLE
Fix express-jwt algorithms missing error

### DIFF
--- a/functions/src/express.ts
+++ b/functions/src/express.ts
@@ -25,7 +25,7 @@ const checkJwt = jwt({
 
   audience: functions.config().auth0.audience,
   issuer: `https://${functions.config().auth0.domain}/`,
-  algorithm: ["RS256"],
+  algorithms: ["RS256"],
 });
 //user must be authenticated on auth0 for the requests to go through
 app.use(checkJwt);


### PR DESCRIPTION
Since express-jwt 6.0.0, the `algorithms` property is required. This typo prevented running on this version.

\<rant>

It sucks because such a typo _should_ have been caught by typescript, because object literals normally can't have extra keys. But whoever wrote the types for express-jwt included `[property: string]: any;` in the interface which means anything goes!

\</rant>