### PR TITLE
feature/link-shortener

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -385,6 +385,12 @@
         "@types/node": "*"
       }
     },
+    "@types/caseless": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
+      "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==",
+      "dev": true
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -499,6 +505,31 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
       "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
     },
+    "@types/request": {
+      "version": "2.48.5",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.5.tgz",
+      "integrity": "sha512-/LO7xRVnL3DxJ1WkPGDQrp4VTV1reX9RkC85mJ+Qzykj2Bdw+mG15aAfDahc76HtknjzE16SX/Yddn6MxVbmGQ==",
+      "dev": true,
+      "requires": {
+        "@types/caseless": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+          "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "@types/serve-static": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.4.tgz",
@@ -507,6 +538,12 @@
         "@types/express-serve-static-core": "*",
         "@types/mime": "*"
       }
+    },
+    "@types/tough-cookie": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
+      "integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==",
+      "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "3.5.0",
@@ -755,6 +792,19 @@
       "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
       "optional": true
     },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
     "astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
@@ -766,6 +816,11 @@
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
     "available-typed-arrays": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz",
@@ -774,6 +829,16 @@
       "requires": {
         "array-filter": "^1.0.0"
       }
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
+      "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA=="
     },
     "axios": {
       "version": "0.19.2",
@@ -801,6 +866,14 @@
       "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
       "requires": {
         "safe-buffer": "5.1.2"
+      }
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "requires": {
+        "tweetnacl": "^0.14.3"
       }
     },
     "bignumber.js": {
@@ -880,6 +953,11 @@
       "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
       "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
     },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -933,6 +1011,14 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
     },
     "commander": {
       "version": "2.20.3",
@@ -1040,8 +1126,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "optional": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cors": {
       "version": "2.8.5",
@@ -1068,6 +1153,14 @@
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
       "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
       "optional": true
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
     },
     "dasherize": {
       "version": "2.0.0",
@@ -1135,6 +1228,11 @@
       "requires": {
         "object-keys": "^1.0.12"
       }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "depd": {
       "version": "1.1.2",
@@ -1216,6 +1314,15 @@
             "util-deprecate": "~1.0.1"
           }
         }
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "ecdsa-sig-formatter": {
@@ -1611,14 +1718,17 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "optional": true
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-diff": {
       "version": "1.2.0",
@@ -1629,8 +1739,7 @@
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -1777,6 +1886,21 @@
       "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
       "optional": true
     },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -1851,6 +1975,14 @@
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
       "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
       "dev": true
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
     },
     "glob": {
       "version": "7.1.6",
@@ -2016,6 +2148,33 @@
           "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
           "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
           "optional": true
+        }
+      }
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
+    "har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "requires": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
+          "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
         }
       }
     },
@@ -2195,6 +2354,16 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "optional": true
         }
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "https-proxy-agent": {
@@ -2398,8 +2567,7 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "optional": true
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-weakmap": {
       "version": "2.0.1",
@@ -2425,6 +2593,11 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -2441,6 +2614,11 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+    },
     "json-bigint": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-0.3.1.tgz",
@@ -2456,17 +2634,26 @@
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
     },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "jsonwebtoken": {
       "version": "8.5.1",
@@ -2490,6 +2677,17 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
+      }
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
       }
     },
     "jwa": {
@@ -2821,6 +3019,11 @@
         "validate-npm-package-license": "^3.0.1"
       }
     },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -2976,6 +3179,11 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
     "pify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
@@ -3058,6 +3266,11 @@
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
+    "psl": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+    },
     "pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -3096,8 +3309,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
       "version": "6.7.0",
@@ -3162,6 +3374,45 @@
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
       "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
       "dev": true
+    },
+    "request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
+      }
     },
     "require-directory": {
       "version": "2.1.1",
@@ -3391,6 +3642,22 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
     "statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
@@ -3555,6 +3822,15 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
+    "tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "requires": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      }
+    },
     "tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -3595,6 +3871,19 @@
       "requires": {
         "tslib": "^1.8.1"
       }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "type-check": {
       "version": "0.4.0",
@@ -3659,7 +3948,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -3701,6 +3989,16 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
     },
     "walkdir": {
       "version": "0.4.1",

--- a/functions/package.json
+++ b/functions/package.json
@@ -15,6 +15,7 @@
   },
   "main": "lib/index.js",
   "dependencies": {
+    "@sentry/node": "^5.19.2",
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",
     "express": "^4.17.1",
@@ -24,11 +25,12 @@
     "helmet": "^3.23.1",
     "jwks-rsa": "^1.8.1",
     "morgan": "^1.10.0",
-    "@sentry/node": "^5.19.2"
+    "request": "^2.88.2"
   },
   "devDependencies": {
     "@types/cors": "^2.8.6",
     "@types/express": "^4.17.6",
+    "@types/request": "^2.48.5",
     "@typescript-eslint/eslint-plugin": "^3.5.0",
     "@typescript-eslint/parser": "^3.5.0",
     "concurrently": "^5.2.0",

--- a/functions/package.json
+++ b/functions/package.json
@@ -16,6 +16,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "@sentry/node": "^5.19.2",
+    "axios": "^0.19.2",
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",
     "express": "^4.17.1",

--- a/functions/src/application/rebrand.ts
+++ b/functions/src/application/rebrand.ts
@@ -1,0 +1,51 @@
+import { Response, Request } from "express";
+import * as Sentry from "@sentry/node";
+import request from "request";
+
+//will generate links like apply.acmutd.co/education
+interface links {
+  slash: string; //what comes after the /
+  destination: string; //link to typeform or website or something
+  title: string; //name of shortened link, not actually used
+}
+
+export const generateLink = async (req: Request, response: Response): Promise<void> => {
+  try {
+    const data: links = req.body;
+    const linkRequest = {
+      destination: data.destination,
+      domain: { fullName: "apply.acmutd.co" },
+      slashtag: data.slash,
+      title: data.title,
+    };
+
+    const requestHeaders = {
+      "Content-Type": "application/json",
+      apikey: "1d051af492364a339ddc158a78c6bb56",
+    };
+
+    request(
+      {
+        uri: "https://api.rebrandly.com/v1/links",
+        method: "POST",
+        body: JSON.stringify(linkRequest),
+        headers: requestHeaders,
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (err: any, res: any, body: string) => {
+        const link = JSON.parse(body);
+        console.log(link);
+        response.json({
+          message: "Successful execution of generateLink",
+          result: link.shortUrl,
+        });
+      }
+    );
+  } catch (error) {
+    Sentry.captureException(error);
+    response.json({
+      message: "Unsuccessful execution of addPermission",
+      error: error,
+    });
+  }
+};

--- a/functions/src/application/rebrand.ts
+++ b/functions/src/application/rebrand.ts
@@ -2,20 +2,22 @@ import { Response, Request } from "express";
 import * as Sentry from "@sentry/node";
 import request from "request";
 import * as functions from "firebase-functions";
+// import axios, { AxiosRequestConfig } from "axios";
 
 //will generate links like apply.acmutd.co/education
 interface links {
   slash: string; //what comes after the /
   destination: string; //link to typeform or website or something
   title: string; //name of shortened link, not actually used
+  subdomain: string; //either apply or rsvp, more to be added later
 }
 
-export const generateLink = async (req: Request, response: Response): Promise<void> => {
+export const createLink = async (req: Request, response: Response): Promise<void> => {
   try {
     const data: links = req.body;
     const linkRequest = {
       destination: data.destination,
-      domain: { fullName: "apply.acmutd.co" },
+      domain: { fullName: `${data.subdomain}.acmutd.co` },
       slashtag: data.slash,
       title: data.title,
     };
@@ -24,7 +26,6 @@ export const generateLink = async (req: Request, response: Response): Promise<vo
       "Content-Type": "application/json",
       apikey: functions.config().rebrandly.apikey,
     };
-
     request(
       {
         uri: "https://api.rebrandly.com/v1/links",
@@ -38,14 +39,146 @@ export const generateLink = async (req: Request, response: Response): Promise<vo
         console.log(link);
         response.json({
           message: "Successful execution of generateLink",
-          result: link.shortUrl,
+          result: link,
         });
       }
     );
   } catch (error) {
     Sentry.captureException(error);
     response.json({
-      message: "Unsuccessful execution of addPermission",
+      message: "Unsuccessful execution of generateLink",
+      error: error,
+    });
+  }
+};
+
+export const updateLink = async (req: Request, response: Response): Promise<void> => {
+  try {
+    const data: links = req.body;
+    const linkRequest = {
+      destination: data.destination,
+      slashtag: data.slash,
+      title: data.title,
+    };
+
+    const requestHeaders = {
+      "Content-Type": "application/json",
+      apikey: functions.config().rebrandly.apikey,
+    };
+    request(
+      {
+        uri: `https://api.rebrandly.com/v1/links/${req.params.link}`,
+        method: "POST",
+        body: JSON.stringify(linkRequest),
+        headers: requestHeaders,
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (err: any, res: any, body: string) => {
+        const link = JSON.parse(body);
+        console.log(link);
+        response.json({
+          message: "Successful execution of updateLink",
+          result: link,
+        });
+      }
+    );
+  } catch (error) {
+    Sentry.captureException(error);
+    response.json({
+      message: "Unsuccessful execution of updateLink",
+      error: error,
+    });
+  }
+};
+
+export const getLink = async (req: Request, response: Response): Promise<void> => {
+  try {
+    const requestHeaders = {
+      "Content-Type": "application/json",
+      apikey: functions.config().rebrandly.apikey,
+    };
+    request(
+      {
+        uri: `https://api.rebrandly.com/v1/links/${req.params.link}`,
+        method: "GET",
+        headers: requestHeaders,
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (err: any, res: any, body: string) => {
+        const link = JSON.parse(body);
+        console.log(link);
+        response.json({
+          message: "Successful execution of getLlink",
+          result: link,
+        });
+      }
+    );
+  } catch (error) {
+    Sentry.captureException(error);
+    response.json({
+      message: "Unsuccessful execution of getLink",
+      error: error,
+    });
+  }
+};
+
+export const deleteLink = async (req: Request, response: Response): Promise<void> => {
+  try {
+    const requestHeaders = {
+      "Content-Type": "application/json",
+      apikey: functions.config().rebrandly.apikey,
+    };
+    request(
+      {
+        uri: `https://api.rebrandly.com/v1/links/${req.params.link}`,
+        method: "DELETE",
+        headers: requestHeaders,
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (err: any, res: any, body: string) => {
+        const link = JSON.parse(body);
+        console.log(link);
+        response.json({
+          message: "Successful execution of getLlink",
+          result: link,
+        });
+      }
+    );
+  } catch (error) {
+    Sentry.captureException(error);
+    response.json({
+      message: "Unsuccessful execution of getLink",
+      error: error,
+    });
+  }
+};
+
+export const getLinks = async (req: Request, response: Response): Promise<void> => {
+  try {
+    const requestHeaders = {
+      "Content-Type": "application/json",
+      apikey: functions.config().rebrandly.apikey,
+    };
+    request(
+      {
+        uri: "https://api.rebrandly.com/v1/links",
+        method: "GET",
+        headers: requestHeaders,
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (err: any, res: any, body: string) => {
+        const link = JSON.parse(body);
+        console.log(link);
+        response.json({
+          message: "Successful execution of getLinks",
+          result: link,
+        });
+      }
+    );
+  } catch (error) {
+    Sentry.captureException(error);
+    response.json({
+      message: "Unsuccessful execution of getLinks",
       error: error,
     });
   }

--- a/functions/src/application/rebrand.ts
+++ b/functions/src/application/rebrand.ts
@@ -1,6 +1,7 @@
 import { Response, Request } from "express";
 import * as Sentry from "@sentry/node";
 import request from "request";
+import * as functions from "firebase-functions";
 
 //will generate links like apply.acmutd.co/education
 interface links {
@@ -21,7 +22,7 @@ export const generateLink = async (req: Request, response: Response): Promise<vo
 
     const requestHeaders = {
       "Content-Type": "application/json",
-      apikey: "1d051af492364a339ddc158a78c6bb56",
+      apikey: functions.config().rebrandly.apikey,
     };
 
     request(

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -52,8 +52,12 @@ app.post("/:division/setStaffMember", divisionFunctions.setStaffMember);
 app.get("/:division/getAllStaff", divisionFunctions.getAllStaff);
 
 /**
- * Link shortener & Applications
+ * Link shortener
  */
-app.post("/generateLink", applicationFunctions.generateLink);
+app.post("/link", applicationFunctions.createLink);
+app.post("/link/:link", applicationFunctions.updateLink);
+app.get("/link/:link", applicationFunctions.getLink);
+app.delete("/link/:link", applicationFunctions.deleteLink);
+app.get("/link", applicationFunctions.getLinks);
 
 export const api = functions.https.onRequest(app);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -7,6 +7,7 @@ import * as authFunctions from "./auth/auth";
 import * as divisionFunctions from "./divisions/divisions";
 import * as roleFunctions from "./roles/roles";
 import * as permissionFunctions from "./roles/permissions";
+import * as applicationFunctions from "./application/rebrand";
 import app from "./express";
 
 //this will match every call made to this api.
@@ -49,5 +50,10 @@ app.post("/updateRole/:role/removePermission", permissionFunctions.removePermiss
  */
 app.post("/:division/setStaffMember", divisionFunctions.setStaffMember);
 app.get("/:division/getAllStaff", divisionFunctions.getAllStaff);
+
+/**
+ * Link shortener & Applications
+ */
+app.post("/generateLink", applicationFunctions.generateLink);
 
 export const api = functions.https.onRequest(app);

--- a/functions/src/services/ErrorService.ts
+++ b/functions/src/services/ErrorService.ts
@@ -1,23 +1,27 @@
-
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 export default class ErrorService {
-
-    static generatePostError<T>(reqObj: any, exampleObj: T) {
-        let response = {error: { message: "You are missing the " }}
-        let missing: string[] = []
-        let wrongType: ({key: string, type: string, correct: string})[] = []
-        for(const key in exampleObj) {
-            if(Object.keys(reqObj).includes(key)) {
-                if(typeof exampleObj[key] !== typeof reqObj[key])
-                    wrongType.push({key, type: typeof reqObj[key], correct: typeof exampleObj[key]})
-            } else missing.push(key);
-        }
-        if(missing.length == 0) return null
-
-        missing.forEach((key, index) => {
-            response.error.message += index+1 != missing.length ? `'${key}', ` : `and '${key}' key(s).`})
-        
-        wrongType.forEach(el => response.error.message += ` You gave the '${el.key}' key a '${el.type}' type, when it should be a '${el.correct}' type.`)
-
-        return response;
+  static generatePostError<T>(reqObj: any, exampleObj: T) {
+    const response = { error: { message: "You are missing the " } };
+    const missing: string[] = [];
+    const wrongType: { key: string; type: string; correct: string }[] = [];
+    for (const key in exampleObj) {
+      if (Object.keys(reqObj).includes(key)) {
+        if (typeof exampleObj[key] !== typeof reqObj[key])
+          wrongType.push({ key, type: typeof reqObj[key], correct: typeof exampleObj[key] });
+      } else missing.push(key);
     }
+    if (missing.length == 0) return null;
+
+    missing.forEach((key, index) => {
+      response.error.message += index + 1 != missing.length ? `'${key}', ` : `and '${key}' key(s).`;
+    });
+
+    wrongType.forEach(
+      (el) =>
+        (response.error.message += ` You gave the '${el.key}' key a '${el.type}' type, when it should be a '${el.correct}' type.`)
+    );
+
+    return response;
+  }
 }


### PR DESCRIPTION
#### Link shortener
Uses rebrand.ly to generate vanity links for ACM

#### Details
 - Uses subdomain `apply.acmutd.co`
 - Appends text after baseURL to generate a shortened link
 - Requires four fields --> `slash`: what comes after `apply.acmutd.co`, `destination`: link that it will redirect to, `subdomain` which can either be apply, rsvp or survey & `title` which is the name of the link
 - Eg --> [apply.acmutd.co/research](apply.acmutd.co/research) points to a typeform for their applications

#### Additional Notes
 - We still need to build a UI for this
 - Needs some additional functions to delete and update at some point