### PR TITLE
feature/hackutd-vanity

### DIFF
--- a/functions/src/application/typeform.ts
+++ b/functions/src/application/typeform.ts
@@ -13,7 +13,7 @@ type form_response = {
   landed_at: string;
   submitted_at: string;
   definition: definition;
-  answers: any; //im lazy, someone plz do this, example at bottom
+  answers: any; //im lazy, someone plz do this
 };
 interface typeform {
   event_id: string;
@@ -60,63 +60,3 @@ export const typeform_webhook = async (request: any, response: any): Promise<voi
     });
   }
 };
-
-/**
- * Collection = typeform
- *     ------ Response to a typeform
- *           --------- id: Test Webhook Connection
- *           --------- [{ questionName: something, answer: something, type: email}]
- */
-
-/**
- * {
-  "event_id": "01EJS56S3J5ZYE0RNVQNWZKQNS",
-  "event_type": "form_response",
-  "form_response": {
-    "form_id": "eVVxaFKf",
-    "token": "pjq79eypbur0ypjq798zr0jbzze7fwba",
-    "landed_at": "2020-09-21T20:20:26Z",
-    "submitted_at": "2020-09-21T20:20:43Z",
-    "definition": {
-      "id": "eVVxaFKf",
-      "title": "Test Webhook Connection",
-      "fields": [
-        {
-          "id": "VIUhZWGJYwco",
-          "title": "Please enter your email address",
-          "type": "email",
-          "ref": "5f5bc559-5bd6-4f6c-8b32-57314232fd5f",
-          "properties": {}
-        },
-        {
-          "id": "UorrqaQ6bCUn",
-          "title": "...",
-          "type": "date",
-          "ref": "da7d3dae-f7ed-4ca6-be13-9ba43e0db0e0",
-          "properties": {}
-        }
-      ]
-    },
-    "answers": [
-      {
-        "type": "email",
-        "email": "harsha.srikara@acmutd.co",
-        "field": {
-          "id": "VIUhZWGJYwco",
-          "type": "email",
-          "ref": "5f5bc559-5bd6-4f6c-8b32-57314232fd5f"
-        }
-      },
-      {
-        "type": "date",
-        "date": "2000-05-25",
-        "field": {
-          "id": "UorrqaQ6bCUn",
-          "type": "date",
-          "ref": "da7d3dae-f7ed-4ca6-be13-9ba43e0db0e0"
-        }
-      }
-    ]
-  }
-}
- */

--- a/functions/src/custom/vanity.ts
+++ b/functions/src/custom/vanity.ts
@@ -106,6 +106,8 @@ export const build_vanity_link = functions.firestore
           slashtag: slashtag,
         };
         create_link(data);
+        send_confirmation(data, email, full_name);
+        console.log(full_name, email);
       }
     } catch (error) {
       Sentry.captureException(error);
@@ -137,4 +139,20 @@ const create_link = async (vanity: vanity): Promise<void> => {
     body: JSON.stringify(linkRequest),
     headers: requestHeaders,
   });
+};
+
+const send_confirmation = (vanity: vanity, email: string, name: string) => {
+  sendgrid.setApiKey(functions.config().sendgrid.apikey);
+  const msg: sendgrid.MailDataRequired = {
+    from: "development@acmutd.co",
+    to: email,
+    dynamicTemplateData: {
+      preheader: "Successful Generation of Vanity Link",
+      subject: "Vanity Link Confirmation",
+      vanity_link: vanity.subdomain + "." + vanity.primary_domain + "/" + vanity.slashtag,
+      full_name: name,
+    },
+    templateId: "d-cd15e958009a43b3b3a8d7352ee12c79",
+  };
+  sendgrid.send(msg);
 };

--- a/functions/src/custom/vanity.ts
+++ b/functions/src/custom/vanity.ts
@@ -63,52 +63,42 @@ export const build_vanity_link = functions.firestore
   .onCreate(async (snap, context) => {
     const document = snap.data();
     try {
-      if (document.typeform_id == "Link Generator") {
-        const typeform_results = document.data;
-        let full_name = "";
-        let email = "";
-        let destination = "";
-        let primary_domain = "";
-        let subdomain = "";
-        let slashtag = "";
-
-        typeform_results.forEach((element: any) => {
-          const fullname_question = "full name";
-          const email_question = "email";
-          const destination_question = "vanity link";
-          const primary_domain_question = "primary domain";
-          const subdomain_question = "vanity domain";
-          const slashtag_question = "slashtag";
-          if (element.question.includes(fullname_question)) {
-            full_name = element.answer;
-          }
-          if (element.question.includes(email_question)) {
-            email = element.answer;
-          }
-          if (element.question.includes(destination_question)) {
-            destination = element.answer;
-          }
-          if (element.question.includes(primary_domain_question)) {
-            primary_domain = element.answer.label;
-          }
-          if (element.question.includes(subdomain_question) && element.answer.label !== "") {
-            subdomain = element.answer.label;
-          }
-          if (element.question.includes(slashtag_question)) {
-            slashtag = element.answer;
-          }
-        });
-
-        const data: Vanity = {
-          destination: destination,
-          primary_domain: primary_domain,
-          subdomain: subdomain,
-          slashtag: slashtag,
-        };
-        create_link(data);
-        send_confirmation(data, email, full_name);
-        console.log(full_name, email);
+      if (document.typeform_id !== "Link Generator") {
+        return;
       }
+      const typeform_results = document.data;
+      let full_name = "";
+      let email = "";
+      let destination = "";
+      let primary_domain = "";
+      let subdomain = "";
+      let slashtag = "";
+
+      const fullname_question = "full name";
+      const email_question = "email";
+      const destination_question = "vanity link";
+      const primary_domain_question = "primary domain";
+      const subdomain_question = "vanity domain";
+      const slashtag_question = "slashtag";
+
+      typeform_results.forEach((element: any) => {
+        if (element.question.includes(fullname_question)) full_name = element.answer;
+        if (element.question.includes(email_question)) email = element.answer;
+        if (element.question.includes(destination_question)) destination = element.answer;
+        if (element.question.includes(primary_domain_question)) primary_domain = element.answer.label;
+        if (element.question.includes(subdomain_question) && element.answer.label !== "")
+          subdomain = element.answer.label;
+        if (element.question.includes(slashtag_question)) slashtag = element.answer;
+      });
+
+      const data: Vanity = {
+        destination: destination,
+        primary_domain: primary_domain,
+        subdomain: subdomain,
+        slashtag: slashtag,
+      };
+      create_link(data);
+      send_confirmation(data, email, full_name);
     } catch (error) {
       Sentry.captureException(error);
     }

--- a/functions/src/custom/vanity.ts
+++ b/functions/src/custom/vanity.ts
@@ -3,7 +3,7 @@ import * as Sentry from "@sentry/node";
 import request from "request";
 import sendgrid from "@sendgrid/mail";
 
-interface vanity {
+interface Vanity {
   destination: string;
   primary_domain: string;
   subdomain: string;
@@ -99,7 +99,7 @@ export const build_vanity_link = functions.firestore
           }
         });
 
-        const data: vanity = {
+        const data: Vanity = {
           destination: destination,
           primary_domain: primary_domain,
           subdomain: subdomain,
@@ -114,7 +114,7 @@ export const build_vanity_link = functions.firestore
     }
   });
 
-const create_link = async (vanity: vanity): Promise<void> => {
+const create_link = async (vanity: Vanity): Promise<void> => {
   const linkRequest = {
     destination: vanity.destination,
     domain: { fullName: vanity.subdomain + "." + vanity.primary_domain },
@@ -141,7 +141,7 @@ const create_link = async (vanity: vanity): Promise<void> => {
   });
 };
 
-const send_confirmation = (vanity: vanity, email: string, name: string) => {
+const send_confirmation = (vanity: Vanity, email: string, name: string) => {
   sendgrid.setApiKey(functions.config().sendgrid.apikey);
   const msg: sendgrid.MailDataRequired = {
     from: "development@acmutd.co",

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -108,5 +108,6 @@ export const api = functions.https.onRequest(app_secure);
 export const challenge = functions.https.onRequest(app_open);
 
 // firestore triggers
+export const build_vanity_link = vanityFunctions.build_vanity_link;
 export const create_vanity_link = vanityFunctions.create_vanity_link;
-export const email_discord_mapper = hacktoberfestFunctions.mapper;
+//export const email_discord_mapper = hacktoberfestFunctions.mapper;

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -110,4 +110,4 @@ export const challenge = functions.https.onRequest(app_open);
 // firestore triggers
 export const build_vanity_link = vanityFunctions.build_vanity_link;
 export const create_vanity_link = vanityFunctions.create_vanity_link;
-//export const email_discord_mapper = hacktoberfestFunctions.mapper;
+export const email_discord_mapper = hacktoberfestFunctions.mapper;


### PR DESCRIPTION
Updates
 - Updated connector now increases the number of vanity links we can make from 100 --> 1000 (no longer uses zapier, uses in-house webhook connection)
 - Revised confirmation to use the email templates with new acm theme
 - Added ability to also create vanity links under the hackutd.co domain