### PR TITLE
HackUTD Endpoints

### DIFF
--- a/functions/src/custom/hackutd.ts
+++ b/functions/src/custom/hackutd.ts
@@ -1,0 +1,93 @@
+import * as functions from "firebase-functions";
+import * as Sentry from "@sentry/node";
+import RequestOptions from "@sendgrid/helpers/classes/request";
+import client from "@sendgrid/client";
+import { firestore } from "../admin/admin";
+
+type quill_profile = {
+  adult: boolean;
+  name: string;
+  school: string;
+  graduationYear: string;
+  gender: string;
+  description: string;
+  essay: string;
+};
+
+type quill_confirmation = {
+  dietaryRestrictions: string[];
+};
+
+type quill_status = {
+  completedProfile: boolean;
+  admitted: boolean;
+  confirmed: boolean;
+  declined: boolean;
+  checkedIn: boolean;
+  reimbursementGiven: boolean;
+  admittedBy: string;
+  confirmBy: number;
+};
+
+interface quill {
+  _id: Record<string, unknown>;
+  profile: quill_profile;
+  confirmation: quill_confirmation;
+  status: quill_status;
+  admin: boolean;
+  timestamp: number;
+  lastUpdated: number;
+  verified: boolean;
+  salt: string;
+  email: string;
+  password: string;
+  __v: number;
+  teamCode: string;
+}
+
+const collectionName = "hackutd";
+
+export const mongo_integration = async (request: any, response: any): Promise<void> => {
+  const data: quill = request.body;
+  try {
+    firestore.collection(collectionName).doc(data.email).set(data);
+  } catch (error) {
+    Sentry.captureException(error);
+  }
+};
+
+/**
+ * Add person to the hacktoberfest mailing list
+ */
+export const uploadToSendgrid = functions.firestore
+  .document("hackutd/{document_name}")
+  .onCreate(async (snap, context) => {
+    const document = snap.data();
+    client.setApiKey(functions.config().sendgrid.apikey);
+    const req: RequestOptions = {
+      method: "PUT",
+      url: "/v3/marketing/contacts",
+      body: {
+        list_ids: ["32aa0cfd-03c1-4b40-919d-4dc403291cb2"],
+        contacts: [
+          {
+            email: document.email,
+            first_name: document.profile.name,
+            //   first_name: first_name,
+            //   last_name: last_name,
+            //   custom_fields: {
+            //     w3_T: discord_username,
+            //     w4_T: discord_snowflake,
+            //   },
+          },
+        ],
+      },
+    };
+    client.request(req);
+    // .then(() => {
+    //   console.log("yay it worked");
+    // })
+    // .catch((err) => {
+    //   console.log("you broke it!", err?.response?.body);
+    // });
+  });

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -16,6 +16,8 @@ import * as eventFunctions from "./events/events";
 import * as vanityFunctions from "./custom/vanity";
 import * as hacktoberfestFunctions from "./custom/hacktoberfest";
 import * as typeformFunctions from "./application/typeform";
+import * as hackutdFunctions from "./custom/hackutd";
+import { send } from "@sendgrid/mail";
 
 //this will match every call made to this api.
 app_secure.all("/", (request, response, next) => {
@@ -85,6 +87,7 @@ app_secure.post("/sendgrid/send", sendgridFunctions.sendTestEmail);
 app_secure.post("/sendgrid/send2", sendgridFunctions.sendDynamicTemplate);
 app_secure.post("/sendgrid/upsertContact", sendgridFunctions.upsertContact);
 app_secure.post("/sendgrid/sendMailingList", sendgridFunctions.sendMailingList);
+app_open.get("/sendgrid/getMailingLists", sendgridFunctions.getMailingLists);
 
 /**
  * Challenges for ACM Development
@@ -104,6 +107,11 @@ app_open.post("/typeform", typeformFunctions.typeform_webhook);
  */
 app_open.post("/htf-development", hacktoberfestFunctions.retrieve_record);
 
+/**
+ * hackutd endpoints
+ */
+app_open.post("/hackutd", hackutdFunctions.mongo_integration);
+
 export const api = functions.https.onRequest(app_secure);
 export const challenge = functions.https.onRequest(app_open);
 
@@ -111,3 +119,4 @@ export const challenge = functions.https.onRequest(app_open);
 export const build_vanity_link = vanityFunctions.build_vanity_link;
 export const create_vanity_link = vanityFunctions.create_vanity_link;
 export const email_discord_mapper = hacktoberfestFunctions.mapper;
+export const hackutd_mapper = hackutdFunctions.uploadToSendgrid;

--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,7 @@ root
 │   │   │   └── challenge.ts
 │   │   ├── custom
 │   │   │   ├── hacktoberfest.ts
+|   |   |   ├── hackutd.ts
 │   │   │   └── vanity.ts
 │   │   ├── divisions
 │   │   │   ├── GET
@@ -86,11 +87,9 @@ root
 
 ### How to Contribute
 
-When testing deployment on a feature branch rename last line in `index.ts` to be as follows
+Reach out to the [Director of Development](mailto:development@acmutd.co) to learn more about how to contribute to our open source projects. If you are interested in joining the team as a developer learn more in the [dev readme](https://github.com/acmutd/Development/blob/master/developer.md). 
 
-`exports.api-YOURNAME = functions.https.onRequest(app);`
-
-When making a pull request to `dev` ensure that it has been reverted to exports.api.
+If you'd like to take ownership over a project or become a core maintainer for these projects learn more about becoming an _ACM Development_ officer in the [officer readme](https://github.com/acmutd/Development/blob/master/dev_officer.md). 
 
 ##### Pull Requests & Issues
 


### PR DESCRIPTION
Notes
 - Create backup of application data from Quill
 - On creation of new application entry save their information to sendgrid

To Do (after question schema has been updated by @darichey)
 - Update `interface quill { }` schema to reflect the different fields
 - Save those fields to SendGrid! **Very Important** Add these fields in particular

<img width="778" alt="Screen Shot 2020-11-04 at 11 16 21 PM" src="https://user-images.githubusercontent.com/42700872/98200685-c40cee00-1ef3-11eb-9867-df28ae758201.png">

 - For the custom object need to create a couple important ones. Can be computed by checking the other fields
 - `isUTDStudent` becuz eventually we may have custom content for ppl at utd and those who are not. Eg. Adding them to the acm mailing list
 - `isInUSA` becuz of prizes and swag and things like that
 - custom parameters for as many of the schema questions as possible. 

Important Note: Custom Field `id`s are very poorly designed in SendGrid. You need to use this api endpoint to figure out what they are called --> `https://api.sendgrid.com/v3/marketing/field_definitions`

More To Do:
 - Add the Mongo Realm Trigger to send the changeEvent data to firestore
