### PR TITLE
Enable middleware for gsuite cloudflare access

### DIFF
--- a/functions/src/application/portal.ts
+++ b/functions/src/application/portal.ts
@@ -17,7 +17,7 @@ export const verify = (request: Request, response: Response): void => {
 
 export const verify_jwt = (request: Request, response: Response): void => {
   response.json({
-    idp: request.body.idp,
+    message: "success",
   });
 };
 

--- a/functions/src/application/portal.ts
+++ b/functions/src/application/portal.ts
@@ -15,7 +15,7 @@ export const verify = (request: Request, response: Response): void => {
   });
 };
 
-export const verify_idp = (request: Request, response: Response): void => {
+export const verify_jwt = (request: Request, response: Response): void => {
   response.json({
     idp: request.body.idp,
   });

--- a/functions/src/express_configs/express_portal.ts
+++ b/functions/src/express_configs/express_portal.ts
@@ -83,22 +83,22 @@ const checkJwt_auth0 = jwt({
   algorithms: ["RS256"],
 });
 
-// const checkJwt_gsuite = jwt({
-//   secret: jwksRsa.expressJwtSecret({
-//     cache: true,
-//     rateLimit: true,
-//     jwksRequestsPerMinute: 5,
-//     jwksUri: `https://${functions.config().cloudflare.domain}/cdn-cgi/access/certs`,
-//   }),
+const checkJwt_gsuite = jwt({
+  secret: jwksRsa.expressJwtSecret({
+    cache: true,
+    rateLimit: true,
+    jwksRequestsPerMinute: 5,
+    jwksUri: `https://${functions.config().cloudflare.domain}/cdn-cgi/access/certs`,
+  }),
 
-//   audience: functions.config().cloudflare.portal_gsuite_audience,
-//   issuer: `https://${functions.config().cloudflare.domain}`,
-//   algorithms: ["RS256"],
-// });
+  audience: functions.config().cloudflare.portal_gsuite_audience,
+  issuer: `https://${functions.config().cloudflare.domain}`,
+  algorithms: ["RS256"],
+});
 //user must be authenticated on auth0 for the requests to go through
 app.use("/auth0", checkJwt_auth0);
 // user must be authenticated on gsuite for the requests to go through
-// app.use("/gsuite", checkJwt_gsuite);
+app.use("/gsuite", checkJwt_gsuite);
 
 function extractAuth0Fields(request: Request, response: Response, next: () => void) {
   request.body.sub = request.user.sub;

--- a/functions/src/routes/express_cf.ts
+++ b/functions/src/routes/express_cf.ts
@@ -13,7 +13,7 @@ app_cf.all("/", (request: Request, response: Response, next: () => void) => {
  * Cloudflare access protected endpoint
  */
 app_cf.get("/verify", portalFunctions.verify); //to be phased out
-app_cf.get("/verify-idp", portalFunctions.verify_idp);
+app_cf.get("/verify-jwt", portalFunctions.verify_jwt);
 
 // http server endpoints
 export default app_cf;

--- a/functions/src/routes/express_portal.ts
+++ b/functions/src/routes/express_portal.ts
@@ -17,8 +17,8 @@ app_portal.all("/", (request: Request, response: Response, next) => {
  * This is because they have common requirements
  * Additional endpoints for separate forms will be on one or the other path
  */
-app_portal.get("/auth0/verify-idp", portalFunctions.verify_idp);
-app_portal.get("/gsuite/verify-idp", portalFunctions.verify_idp);
+app_portal.get("/auth0/verify-jwt", portalFunctions.verify_jwt);
+app_portal.get("/gsuite/verify-jwt", portalFunctions.verify_jwt);
 
 app_portal.get("/auth0/verify", portalFunctions.verify);
 app_portal.get("/gsuite/verify", portalFunctions.verify);


### PR DESCRIPTION
- Allows requests to check jwt through /gsuite route.
- Refactor endpoint and functions containing /verify-idp to /verify-jwt to accurately represent purpose
- Change response from idp to generic success message