### PR TITLE
Update doppler-firebase-deploy.yml

### DIFF
--- a/.github/workflows/doppler-firebase-deploy.yml
+++ b/.github/workflows/doppler-firebase-deploy.yml
@@ -33,5 +33,6 @@ jobs:
       - name: Set Firebase Token
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        run: echo "Set Firebase Token"
       - name: Deploy
         run: npm run deploy


### PR DESCRIPTION
Resolves issue where every step must define a `uses` or `run` key