### PR TITLE
Internal/housekeeping

### DIFF
--- a/functions/src/custom/event.ts
+++ b/functions/src/custom/event.ts
@@ -1,7 +1,6 @@
 import { firestore } from "../admin/admin";
 import logger from "../services/logging";
 import { send_dynamic_template, sendgrid_email } from "../mail/sendgrid";
-import { get_auth_token, add_callback } from "../admin/auth0";
 import * as Sentry from "@sentry/node";
 import { log_to_slack, slack_message } from "../services/slack";
 import { environment } from "../environment";
@@ -76,7 +75,6 @@ export const create_event = async (document: FirebaseFirestore.DocumentData): Pr
     };
 
     await create_map(data);
-    await add_callback(`https://${environment.URL_PROD}/checkin/${path_name}`, await get_auth_token());
     await send_dynamic_template(email_options);
     await log_to_slack(message);
   } catch (err) {

--- a/functions/src/custom/event.ts
+++ b/functions/src/custom/event.ts
@@ -52,7 +52,7 @@ export const create_event = async (document: FirebaseFirestore.DocumentData): Pr
         first_name: first_name,
         last_name: last_name,
         name: name,
-        checkin_link: `https://${environment.URL_PROD}/checkin/${path_name}`,
+        checkin_link: `${environment.URL_PROD}/checkin/${path_name}`,
         date: date,
         preheader: "Successful Event Check-in Creation Connection",
         subject: "Event Creation Confirmation",
@@ -71,7 +71,7 @@ export const create_event = async (document: FirebaseFirestore.DocumentData): Pr
       form_name: "Event Check-in Generator",
       name: first_name + " " + last_name,
       email: email,
-      url: `https://${environment.URL_PROD}/checkin/${path_name}`,
+      url: `${environment.URL_PROD}/checkin/${path_name}`,
     };
 
     await create_map(data);

--- a/functions/src/custom/form.ts
+++ b/functions/src/custom/form.ts
@@ -3,7 +3,6 @@ import logger from "../services/logging";
 import { send_dynamic_template, sendgrid_email, create_marketing_list } from "../mail/sendgrid";
 import * as Sentry from "@sentry/node";
 import axios from "axios";
-import { get_auth_token, add_callback } from "../admin/auth0";
 import { Response, Request } from "express";
 import { create_map, SendgridDoc } from "../custom/sendgrid_map";
 import { log_to_slack, slack_message } from "../services/slack";
@@ -95,7 +94,6 @@ export const add_form = async (document: FirebaseFirestore.DocumentData): Promis
 
     await create_map(generic_email);
     await create_form_map(data);
-    await add_callback(`https://${environment.URL_PROD}/forms/${endpoint}`, await get_auth_token());
     await send_dynamic_template(email_options);
     await log_to_slack(message);
   } catch (err) {

--- a/functions/src/custom/form.ts
+++ b/functions/src/custom/form.ts
@@ -56,7 +56,7 @@ export const add_form = async (document: FirebaseFirestore.DocumentData): Promis
         first_name: first_name,
         last_name: last_name,
         description: description,
-        form_link: `https://${environment.URL_PROD}/forms/${endpoint}`,
+        form_link: `${environment.URL_PROD}/forms/${endpoint}`,
         typeform_name: typeform_name,
         preheader: "Successful Form Addition to Portal",
         subject: "Form Addition Confirmation",
@@ -89,7 +89,7 @@ export const add_form = async (document: FirebaseFirestore.DocumentData): Promis
       form_name: "Typeform Adder",
       name: first_name + " " + last_name,
       email: email,
-      url: `https://${environment.URL_PROD}/forms/${endpoint}`,
+      url: `${environment.URL_PROD}/forms/${endpoint}`,
     };
 
     await create_map(generic_email);

--- a/functions/src/express_configs/express_portal.ts
+++ b/functions/src/express_configs/express_portal.ts
@@ -37,7 +37,8 @@ app.use(Sentry.Handlers.tracingHandler());
 
 app.use(
   cors({
-    origin: [environment.URL_LOCAL as string, environment.URL_PROD as string, environment.URL_DEV as string],
+    // Split the environment variable on a sequence of one or more commas or spaces
+    origin: environment.URL_ORIGINS?.trim().split(/[\s,]+/),
   })
 );
 app.use(bodyParser.json());


### PR DESCRIPTION
- Removes unnecessary add_callback() since we only use one callback url now
- Fixes issue where an extra `https://` is prepended on url in the confirmation email and in #core-feed
- Splits the secret by commas, so now we can change to be as many or as few origins from within Doppler