### PR TITLE
Added API endpoint to generate Vanity link

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "functions",
       "dependencies": {
         "@logdna/logger": "^2.1.3",
         "@mailchimp/mailchimp_marketing": "^3.0.12",
@@ -16,6 +17,7 @@
         "crypto": "^1.0.1",
         "express": "^4.17.1",
         "express-jwt": "6.0.0",
+        "express-validator": "^6.12.2",
         "firebase-admin": "^8.10.0",
         "firebase-functions": "^3.13.0",
         "helmet": "^3.23.1",
@@ -2413,6 +2415,18 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/express-unless/-/express-unless-0.3.1.tgz",
       "integrity": "sha1-JVfBRudb65A+LSR/m1ugFFJpbiA="
+    },
+    "node_modules/express-validator": {
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-6.12.2.tgz",
+      "integrity": "sha512-UMVck7ZWrKH7eX75CRYk/pAc9jxZk8Ddsdkukw1R7LTWuQNiDaooz6nVfIdg33qZUHCuv2m2o+RS4pTMaLjGmA==",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "validator": "^13.5.2"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -5355,6 +5369,14 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "node_modules/validator": {
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.6.0.tgz",
+      "integrity": "sha512-gVgKbdbHgtxpRyR8K0O6oFZPhhB5tT1jeEHZR0Znr9Svg03U0+r9DXWMrnRAB+HtCStDQKlaIZm42tVsVjqtjg==",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -7510,6 +7532,15 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/express-unless/-/express-unless-0.3.1.tgz",
       "integrity": "sha1-JVfBRudb65A+LSR/m1ugFFJpbiA="
+    },
+    "express-validator": {
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-6.12.2.tgz",
+      "integrity": "sha512-UMVck7ZWrKH7eX75CRYk/pAc9jxZk8Ddsdkukw1R7LTWuQNiDaooz6nVfIdg33qZUHCuv2m2o+RS4pTMaLjGmA==",
+      "requires": {
+        "lodash": "^4.17.21",
+        "validator": "^13.5.2"
+      }
     },
     "extend": {
       "version": "3.0.2",
@@ -9870,6 +9901,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "validator": {
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.6.0.tgz",
+      "integrity": "sha512-gVgKbdbHgtxpRyR8K0O6oFZPhhB5tT1jeEHZR0Znr9Svg03U0+r9DXWMrnRAB+HtCStDQKlaIZm42tVsVjqtjg=="
     },
     "vary": {
       "version": "1.1.2",

--- a/functions/package.json
+++ b/functions/package.json
@@ -27,6 +27,7 @@
     "crypto": "^1.0.1",
     "express": "^4.17.1",
     "express-jwt": "6.0.0",
+    "express-validator": "^6.12.2",
     "firebase-admin": "^8.10.0",
     "firebase-functions": "^3.13.0",
     "helmet": "^3.23.1",

--- a/functions/src/application/portal.ts
+++ b/functions/src/application/portal.ts
@@ -317,7 +317,7 @@ export const create_vanity_link = async (req: Request, res: Response) => {
     subdomain,
     slashtag,
   }).catch((err) => {
-    error = err.response.data;
+    error = [err.response.data];
   });
 
   if (!error)

--- a/functions/src/application/portal.ts
+++ b/functions/src/application/portal.ts
@@ -5,6 +5,7 @@ import { send_dynamic_template, upsert_contact } from "../mail/sendgrid";
 import admin from "firebase-admin";
 import logger from "../services/logging";
 import { environment } from "../environment";
+import { build_vanity_link_v2 } from "../custom/vanity";
 
 const profile_collection = environment.FIRESTORE_PROFILE_COLLECTION as string;
 const event_collection = environment.FIRESTORE_EVENT_COLLECTION as string;
@@ -301,4 +302,32 @@ export const get_developer_profile = async (request: Request, response: Response
       exists: false,
     });
   }
+};
+
+export const create_vanity_link = async (req: Request, res: Response) => {
+  const { first_name, last_name, email, destination, primary_domain, subdomain, slashtag } = req.body;
+  let error = null;
+
+  await build_vanity_link_v2({
+    first_name,
+    last_name,
+    email,
+    destination,
+    primary_domain,
+    subdomain,
+    slashtag,
+  }).catch((err) => {
+    error = err.response.data;
+  });
+
+  if (!error)
+    return res.status(201).send({
+      message: "Sucessfully created Vanity link",
+      url: `https://${subdomain}.${primary_domain}/${slashtag}`,
+    });
+
+  return res.status(400).send({
+    message: "Failed to create Vanity link",
+    error,
+  });
 };

--- a/functions/src/custom/vanity.ts
+++ b/functions/src/custom/vanity.ts
@@ -10,6 +10,12 @@ export interface Vanity {
   slashtag: string;
 }
 
+export interface VanityReqBody extends Vanity {
+  first_name: string;
+  last_name: string;
+  email: string;
+}
+
 export const build_vanity_link = async (document: FirebaseFirestore.DocumentData): Promise<void> => {
   const typeform_results = document.data;
   let first_name = "";
@@ -104,17 +110,15 @@ const create_link = async (vanity: Vanity): Promise<void> => {
     });
 };
 
-export const build_vanity_link_v2 = async (request_data: {
-  first_name: string;
-  last_name: string;
-  email: string;
-  destination: string;
-  primary_domain: string;
-  subdomain: string;
-  slashtag: string;
-}) => {
-  const { first_name, last_name, email, destination, primary_domain, subdomain, slashtag } = request_data;
-
+export const build_vanity_link_v2 = async ({
+  first_name,
+  last_name,
+  email,
+  destination,
+  primary_domain,
+  subdomain,
+  slashtag,
+}: VanityReqBody) => {
   const vanityData: Vanity = {
     destination,
     primary_domain,

--- a/functions/src/custom/vanity.ts
+++ b/functions/src/custom/vanity.ts
@@ -173,7 +173,7 @@ const create_link_v2 = async (vanity: Vanity) => {
   );
 
   const { data } = await axios.post(
-    `https://api.rebrandly.com/v1/links/${Object.keys(res.data).length !== 0 ? res.data[0].id : ""}`,
+    `${environment.REBRANDLY_URL}${Object.keys(res.data).length !== 0 ? res.data[0].id : ""}`,
     linkRequest,
     {
       headers: requestHeaders,

--- a/functions/src/custom/vanity.ts
+++ b/functions/src/custom/vanity.ts
@@ -150,12 +150,8 @@ const create_link_v2 = async (vanity: Vanity) => {
     slashtag: vanity.slashtag,
   };
 
-  let apikey = "";
-  if (vanity.primary_domain === "acmutd.co") {
-    apikey = `${environment.REBRANDLY_APIKEY}`;
-  } else {
-    apikey = `${environment.REBRANDLY_APIKEY2}`;
-  }
+  const apikey =
+    vanity.primary_domain === environment.URL_ROOT ? environment.REBRANDLY_APIKEY : environment.REBRANDLY_APIKEY2;
 
   const requestHeaders = {
     "Content-Type": "application/json",
@@ -166,22 +162,20 @@ const create_link_v2 = async (vanity: Vanity) => {
     headers: requestHeaders,
   };
 
+  // Will be used to determine whether we are trying to create a new link or update an already exist link
   const res = await axios.get(
     `https://api.rebrandly.com/v1/links?domain.fullName=${linkRequest.domain.fullName}&slashtag=${linkRequest.slashtag}`,
     config
   );
 
-  if (Object.keys(res.data).length !== 0) {
-    const { data } = await axios.post(`https://api.rebrandly.com/v1/links/${res.data[0].id}`, linkRequest, {
+  const { data } = await axios.post(
+    `https://api.rebrandly.com/v1/links/${Object.keys(res.data).length !== 0 ? res.data[0].id : ""}`,
+    linkRequest,
+    {
       headers: requestHeaders,
-    });
-    return data;
-  } else {
-    const { data } = await axios.post("https://api.rebrandly.com/v1/links", linkRequest, {
-      headers: requestHeaders,
-    });
-    return data;
-  }
+    }
+  );
+  return data;
 };
 
 const send_confirmation = (

--- a/functions/src/express_configs/express_portal.ts
+++ b/functions/src/express_configs/express_portal.ts
@@ -111,7 +111,7 @@ function extractAuth0Fields(request: Request, response: Response, next: () => vo
 app.use(extractAuth0Fields);
 
 app.use(
-  "/auth0/vanity/create",
+  "/gsuite/vanity/create",
   [
     requireField({
       fieldName: "first_name",

--- a/functions/src/express_configs/express_portal.ts
+++ b/functions/src/express_configs/express_portal.ts
@@ -12,6 +12,7 @@ import cors from "cors";
 import * as bodyParser from "body-parser";
 import { Response, Request } from "express";
 import { environment } from "../environment";
+import { requireField, validateRequest } from "../services/validate-request";
 
 const app = express();
 
@@ -108,6 +109,37 @@ function extractAuth0Fields(request: Request, response: Response, next: () => vo
   next();
 }
 app.use(extractAuth0Fields);
+
+app.use(
+  "/auth0/vanity/create",
+  [
+    requireField({
+      fieldName: "first_name",
+      onErrorMsg: "First name is required",
+    }),
+    requireField({
+      fieldName: "last_name",
+      onErrorMsg: "Last name is required",
+    }),
+    requireField({
+      fieldName: "destination",
+      onErrorMsg: "Destination URL is required",
+    }),
+    requireField({
+      fieldName: "primary_domain",
+      onErrorMsg: "Primary domain is required",
+    }),
+    requireField({
+      fieldName: "subdomain",
+      onErrorMsg: "Subdomain is required",
+    }),
+    requireField({
+      fieldName: "slashtag",
+      onErrorMsg: "Slashtag is required",
+    }),
+  ],
+  validateRequest({ onErrorMsg: "Failed to create Vanity link" })
+);
 
 /**
  * Log entire request

--- a/functions/src/routes/express_open.ts
+++ b/functions/src/routes/express_open.ts
@@ -11,6 +11,7 @@ import * as typeformFunctions from "../application/typeform";
 import * as errorFunctions from "../services/ErrorService";
 import { upsertContact } from "../mail/sendgrid";
 import { debug_logger } from "../services/logging";
+import { create_vanity_link } from "../application/portal";
 
 /**
  * Match all requests
@@ -47,5 +48,8 @@ app_open.post("/htf-development", hacktoberfestFunctions.retrieve_record);
  * Endpoint to add people to ACM's mailing list
  */
 app_open.post("/add-contact", upsertContact);
+
+// Create Vanity Link
+app_open.post("/vanity/create", create_vanity_link);
 
 export default app_open;

--- a/functions/src/routes/express_open.ts
+++ b/functions/src/routes/express_open.ts
@@ -11,7 +11,6 @@ import * as typeformFunctions from "../application/typeform";
 import * as errorFunctions from "../services/ErrorService";
 import { upsertContact } from "../mail/sendgrid";
 import { debug_logger } from "../services/logging";
-import { create_vanity_link } from "../application/portal";
 
 /**
  * Match all requests
@@ -48,8 +47,5 @@ app_open.post("/htf-development", hacktoberfestFunctions.retrieve_record);
  * Endpoint to add people to ACM's mailing list
  */
 app_open.post("/add-contact", upsertContact);
-
-// Create Vanity Link
-app_open.post("/vanity/create", create_vanity_link);
 
 export default app_open;

--- a/functions/src/routes/express_portal.ts
+++ b/functions/src/routes/express_portal.ts
@@ -7,7 +7,6 @@ import * as portalFunctions from "../application/portal";
 import { get_active_applications } from "../custom/form";
 import { get_user_metadata } from "../admin/auth0";
 import { verify_in_acm_server } from "../admin/discord";
-import { requireField, validateRequest } from "../services/validate-request";
 
 //this will match every call made to this api.
 app_portal.all("/", (request: Request, response: Response, next) => {
@@ -36,37 +35,7 @@ app_portal.get("/auth0/discord", get_user_metadata);
 app_portal.post("/auth0/verify-discord", verify_in_acm_server);
 
 // Create Vanity Link
-app_portal.post(
-  "/auth0/vanity/create",
-  [
-    requireField({
-      fieldName: "first_name",
-      onErrorMsg: "First name is required",
-    }),
-    requireField({
-      fieldName: "last_name",
-      onErrorMsg: "Last name is required",
-    }),
-    requireField({
-      fieldName: "destination",
-      onErrorMsg: "Destination URL is required",
-    }),
-    requireField({
-      fieldName: "primary_domain",
-      onErrorMsg: "Primary domain is required",
-    }),
-    requireField({
-      fieldName: "subdomain",
-      onErrorMsg: "Subdomain is required",
-    }),
-    requireField({
-      fieldName: "slashtag",
-      onErrorMsg: "Slashtag is required",
-    }),
-  ],
-  validateRequest({ onErrorMsg: "Failed to create Vanity link" }),
-  portalFunctions.create_vanity_link
-);
+app_portal.post("/auth0/vanity/create", portalFunctions.create_vanity_link);
 
 // http server endpoints
 export default app_portal;

--- a/functions/src/routes/express_portal.ts
+++ b/functions/src/routes/express_portal.ts
@@ -7,6 +7,7 @@ import * as portalFunctions from "../application/portal";
 import { get_active_applications } from "../custom/form";
 import { get_user_metadata } from "../admin/auth0";
 import { verify_in_acm_server } from "../admin/discord";
+import { requireField, validateRequest } from "../services/validate-request";
 
 //this will match every call made to this api.
 app_portal.all("/", (request: Request, response: Response, next) => {
@@ -35,7 +36,37 @@ app_portal.get("/auth0/discord", get_user_metadata);
 app_portal.post("/auth0/verify-discord", verify_in_acm_server);
 
 // Create Vanity Link
-app_portal.post("/auth0/vanity/create", portalFunctions.create_vanity_link);
+app_portal.post(
+  "/auth0/vanity/create",
+  [
+    requireField({
+      fieldName: "first_name",
+      onErrorMsg: "First name is required",
+    }),
+    requireField({
+      fieldName: "last_name",
+      onErrorMsg: "Last name is required",
+    }),
+    requireField({
+      fieldName: "destination",
+      onErrorMsg: "Destination URL is required",
+    }),
+    requireField({
+      fieldName: "primary_domain",
+      onErrorMsg: "Primary domain is required",
+    }),
+    requireField({
+      fieldName: "subdomain",
+      onErrorMsg: "Subdomain is required",
+    }),
+    requireField({
+      fieldName: "slashtag",
+      onErrorMsg: "Slashtag is required",
+    }),
+  ],
+  validateRequest({ onErrorMsg: "Failed to create Vanity link" }),
+  portalFunctions.create_vanity_link
+);
 
 // http server endpoints
 export default app_portal;

--- a/functions/src/routes/express_portal.ts
+++ b/functions/src/routes/express_portal.ts
@@ -34,5 +34,8 @@ app_portal.get("/auth0/applications", get_active_applications);
 app_portal.get("/auth0/discord", get_user_metadata);
 app_portal.post("/auth0/verify-discord", verify_in_acm_server);
 
+// Create Vanity Link
+app_portal.post("/auth0/vanity/create", portalFunctions.create_vanity_link);
+
 // http server endpoints
 export default app_portal;

--- a/functions/src/routes/express_portal.ts
+++ b/functions/src/routes/express_portal.ts
@@ -35,7 +35,7 @@ app_portal.get("/auth0/discord", get_user_metadata);
 app_portal.post("/auth0/verify-discord", verify_in_acm_server);
 
 // Create Vanity Link
-app_portal.post("/auth0/vanity/create", portalFunctions.create_vanity_link);
+app_portal.post("/gsuite/vanity/create", portalFunctions.create_vanity_link);
 
 // http server endpoints
 export default app_portal;

--- a/functions/src/services/validate-request.ts
+++ b/functions/src/services/validate-request.ts
@@ -1,0 +1,40 @@
+import { body, validationResult } from "express-validator";
+import { NextFunction, Request, Response } from "express";
+
+/**
+ *
+ * Function to enforce a required field in request body
+ *
+ * @param fieldName - name of field that needs to be enforced as required
+ * @param onErrorMsg - if this field is not included, an error object will be returned including the message stored in this variable
+ *
+ *
+ */
+export const requireField = ({ fieldName, onErrorMsg }: { fieldName: string; onErrorMsg: string }) => {
+  return body(fieldName).not().isEmpty().withMessage(onErrorMsg);
+};
+
+/**
+ *
+ * Middleware function to validate result upon validating request body using express-validator
+ *
+ * @param onErrorMsg - Upon validation failure, response will return an object with the message stored in this variable
+ *
+ *
+ */
+export const validateRequest = ({ onErrorMsg }: { onErrorMsg: string }) => {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
+        message: onErrorMsg,
+        error: errors.array().map((error) => ({
+          msg: error.msg,
+          location: error.location,
+          param: error.param,
+        })),
+      });
+    }
+    return next();
+  };
+};

--- a/functions/src/services/validate-request.ts
+++ b/functions/src/services/validate-request.ts
@@ -3,14 +3,27 @@ import { NextFunction, Request, Response } from "express";
 
 /**
  *
- * Function to enforce a required field in request body
+ * Interface representing object containing parameters used by requireField
  *
  * @param fieldName - name of field that needs to be enforced as required
  * @param onErrorMsg - if this field is not included, an error object will be returned including the message stored in this variable
  *
+ */
+interface RequireFieldParams {
+  fieldName: string;
+  onErrorMsg: string;
+}
+
+/**
+ *
+ * Function to enforce a required field in request body
+ *
+ * Parameter documentation can be found above
+ *
+ * @return - a middleware function that will be used by express-validator to check whether given field is included in request body
  *
  */
-export const requireField = ({ fieldName, onErrorMsg }: { fieldName: string; onErrorMsg: string }) => {
+export const requireField = ({ fieldName, onErrorMsg }: RequireFieldParams) => {
   return body(fieldName).not().isEmpty().withMessage(onErrorMsg);
 };
 
@@ -20,6 +33,7 @@ export const requireField = ({ fieldName, onErrorMsg }: { fieldName: string; onE
  *
  * @param onErrorMsg - Upon validation failure, response will return an object with the message stored in this variable
  *
+ * @return - a middleware function that will return 400 response if validation fails
  *
  */
 export const validateRequest = ({ onErrorMsg }: { onErrorMsg: string }) => {

--- a/functions/src/utilities/errors/BadRequestError.ts
+++ b/functions/src/utilities/errors/BadRequestError.ts
@@ -1,0 +1,8 @@
+import { CustomError } from "./CustomError";
+
+export class BadRequestError extends CustomError {
+  statusCode = 400;
+  constructor(message: string, errors: any[]) {
+    super(message, errors);
+  }
+}

--- a/functions/src/utilities/errors/CustomError.ts
+++ b/functions/src/utilities/errors/CustomError.ts
@@ -1,0 +1,12 @@
+export abstract class CustomError extends Error {
+  statusCode = 500;
+  constructor(message: string, public errors: any[]) {
+    super(message);
+  }
+  serialize() {
+    return {
+      message: this.message,
+      errors: this.errors,
+    };
+  }
+}


### PR DESCRIPTION
## Pull Request `vanity-link`

Resolves #109 

## Update
- Most recent PR resolves the suggestions made by @WillieCubed  and @harshasrikara, including code refactoring, improvements in type-safety and documentations, and integration with Sentry for error-capturing.   
- Migrated API endpoint to `POST /portal/gsuite/vanity/create`.

## Details
 1.  Created a new API endpoint at ~~`POST /portal/auth0/vanity/create`~~ `POST /portal/gsuite/vanity/create` to allow generating a Vanity link without having to fill out a Typeform as being done currently.
 2.  As we are migrating to using API approach instead of Typeform, some modifications to the logic have to be made to address possible errors of attempting to create a Vanity link with subdomain not supported by our primary domain. Therefore, this PR currently resolves #109 by creating new functions alongside with original ones so that production code will not be affected upon merging PR. 
 3. Implemented validation for the mentioned API endpoint to ensure that necessary fields are provided. As a result, additional functions are introduced into the codebase so that logic can be reused later on. 

## Usage
1. Currently, the following is the interface of the request body in terms of the required fields:
```
interface RequestBody{
    first_name: string;
    last_name: string;
    destination: string;
    primary_domain: string;
    subdomain: string;
    slashtag: string;
}
```
